### PR TITLE
fix reload & html error

### DIFF
--- a/app/functions/webapp/ext/controller/LRExtend.controller.js
+++ b/app/functions/webapp/ext/controller/LRExtend.controller.js
@@ -8,12 +8,13 @@ sap.ui.define(
           
           },
           onViewNeedsRefresh: function () {  
-            const holder = document.getElementById("functions::FunctionsList--fe::CustomTab::tableView1--holder");
+            // const holder = document.getElementById("functions::FunctionsList--fe::CustomTab::tableView1--holder");
+            const holderControl = this.base.byId(this.getView().getId() + "--fe::CustomTab::tableView1--holder");
             const router = null; //this.base.getRouter();
-            if (!this._diagram) {
+            // if (!this._diagram) {
               this._diagram = new Diagram(router);
-              this._diagram.createDiagram(holder);
-            }
+              this._diagram.createDiagram(holderControl.getDomRef());
+            // }
           },
         },
       });

--- a/app/functions/webapp/ext/view/CustomViewWithButton.fragment.xml
+++ b/app/functions/webapp/ext/view/CustomViewWithButton.fragment.xml
@@ -1,4 +1,4 @@
-<core:FragmentDefinition xmlns="sap.m" xmlns:core="sap.ui.core" xmlns:html="http://www.w3.org/1999/xhtml">
+<core:FragmentDefinition xmlns:layout="sap.ui.layout" xmlns="sap.m" xmlns:core="sap.ui.core">
     <Panel
 		headerText="Root Entity"
 		class="sapUiResponsiveMargin"
@@ -6,7 +6,7 @@
 	>
         <content>
             <Button text="My Custom Action" id="customButton1" class="sapUiSmallMarginEnd" />
+            <HBox id="holder" height="500px"></HBox>
        </content>
-	     <html:div id="holder" style='height: 500px'></html:div>
     </Panel>
 </core:FragmentDefinition>


### PR DESCRIPTION
- Error about html tag is gone by using a HBox instead of an html div.
- Switching between tabs somehow resets everything in the panel and requires to be generated again. Therefore I removed the check if it already exists. 

=> A better solution might be to wrap this into a control to have full control of the rendering behavior.